### PR TITLE
Depend on xonda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install
   skip: True  # [py2k]
 
@@ -23,6 +23,7 @@ requirements:
     - python
     - xonsh
     - lazyasd
+    - xonda
 
 test:
   imports:


### PR DESCRIPTION
Otherwise the run_in_conda_env context manager does not work.